### PR TITLE
Remove deprecated platforms and calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 group :unit do
   gem 'berkshelf'
-  gem 'chefspec', '~> 3.1'
+  gem 'chefspec'
 end
 
 group :integration do
@@ -16,6 +16,6 @@ group :integration do
   gem 'kitchen-docker'
   gem 'kitchen-vagrant'
   gem 'serverspec'
-  gem 'busser-serverspec', '~> 0.2.6'
+  gem 'busser-serverspec'
   gem 'knife-solo_data_bag'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license          'Apache 2.0'
 description      'Installs/Configures solr-jetty'
 long_description 'Installs/Configures solr-jetty'
-version          '0.1.2'
+version          '0.1.3'
 
 depends 'libarchive', '~> 0.4.1'
 depends 'java', '~> 1.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'rspec/expectations'
 require 'chefspec'
 require 'chefspec/berkshelf'
-require 'chefspec/server'
 
 at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 describe 'solr-jetty::default' do
 
   platforms = {
-      'centos' => ['6.5'],
-      'ubuntu' => ['12.04', '14.04']
+      'centos' => ['6.6'],
+      'ubuntu' => ['14.04']
   }
 
   platforms.each do |platform, versions|
@@ -13,7 +13,7 @@ describe 'solr-jetty::default' do
 
       context "on #{platform.capitalize} #{version}" do
         let (:chef_run) do
-          ChefSpec::Runner.new(log_level: :warn, platform: platform, version: version) do |node|
+          ChefSpec::SoloRunner.new(log_level: :error, platform: platform, version: version) do |node|
             # set additional node attributes here
           end.converge(described_recipe)
         end

--- a/spec/unit/recipes/package_spec.rb
+++ b/spec/unit/recipes/package_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 describe 'solr-jetty::package' do
 
   platforms = {
-      'centos' => ['6.5'],
-      'ubuntu' => ['12.04', '14.04']
+      'centos' => ['6.6'],
+      'ubuntu' => ['14.04']
   }
 
   platforms.each do |platform, versions|
@@ -13,7 +13,7 @@ describe 'solr-jetty::package' do
 
       context "on #{platform.capitalize} #{version}" do
         let (:chef_run) do
-          ChefSpec::Runner.new(log_level: :warn, platform: platform, version: version) do |node|
+          ChefSpec::SoloRunner.new(log_level: :error, platform: platform, version: version) do |node|
             # set additional node attributes here
           end.converge(described_recipe)
         end

--- a/spec/unit/recipes/prep_spec.rb
+++ b/spec/unit/recipes/prep_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 describe 'solr-jetty::prep' do
 
   platforms = {
-      'centos' => ['6.5'],
-      'ubuntu' => ['12.04', '14.04']
+      'centos' => ['6.6'],
+      'ubuntu' => ['14.04']
   }
 
   platforms.each do |platform, versions|
@@ -13,7 +13,7 @@ describe 'solr-jetty::prep' do
 
       context "on #{platform.capitalize} #{version}" do
         let (:chef_run) do
-          ChefSpec::Runner.new(log_level: :warn, platform: platform, version: version) do |node|
+          ChefSpec::SoloRunner.new(log_level: :error, platform: platform, version: version) do |node|
             # set additional node attributes here
           end.converge(described_recipe)
         end


### PR DESCRIPTION
* Remove Ubuntu 12.0.4
* Bump to Centos 6.6
* Replace deprecated calls to ChefSpec::Runner with  ChefSpec::SoloRunner
