### PR TITLE
Solr/Jetty should use a simple systemd service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,7 @@
 # 0.2.0
 
 * Add support for CentOS 7 and Systemd
+
+# 0.2.1
+
+* Change Systemd unit for solr to be a simple service

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'camden@northpage.com'
 license          'Apache 2.0'
 description      'Installs/Configures solr-jetty'
 long_description 'Installs/Configures solr-jetty'
-version          '0.2.0'
+version          '0.2.1'
 
 depends 'libarchive', '~> 0.4.1'
 depends 'java', '~> 1.0'

--- a/templates/centos/solr-jetty.systemd.erb
+++ b/templates/centos/solr-jetty.systemd.erb
@@ -7,14 +7,14 @@ Description=solr-jetty
 After=syslog.target
 
 [Service]
-Type=forking
+Type=simple
 EnvironmentFile=<%= @config %>
 User=<%= @solr_user %>
 PIDFile=/var/run/jetty.pid
 WorkingDirectory=<%= @solr_dir %>
 ExecStart=<%= @java %> -Dsolr.solr.home=<%= @solr_dir %>/solr -Dsolr.data.dir=<%= @solr_data %> \
   -Djetty.logs=<%= @solr_dir %>/logs -Djetty.home=<%= @solr_dir %> -Djava.io.tmpdir=/tmp -jar \
-  <%= @solr_dir %>/start.jar --daemon
+  <%= @solr_dir %>/start.jar
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This fixes an issue where systemd will eventually shutdown solr because it doesn't think it started.  :rage:   By converting this to a 'simple' service and not forking, systemd can control the process properly.